### PR TITLE
chore: update Tini package build for bookworm

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 
 FROM base AS runner
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y tini=0.19.0-1 \
+  && apt-get install --no-install-recommends -y tini=0.19.0-1+b3 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/storefront/Dockerfile
+++ b/storefront/Dockerfile
@@ -37,7 +37,7 @@ RUN \
 
 FROM base AS runner
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y tini=0.19.0-1 \
+  && apt-get install --no-install-recommends -y tini=0.19.0-1+b3 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Update Tini package build version to match latest provided in bookworm apt repository.