### PR TITLE
fix: update postgres volume path

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
           cpus: 2
           memory: 1024M
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "medusa-starter"]
       interval: 10s
@@ -41,7 +41,7 @@ services:
     environment:
       - MEILI_MASTER_KEY=ms
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:7700']
+      test: ["CMD", "curl", "-f", "http://localhost:7700"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
PostgreSQL 18+ changes how database data is stored inside the container.
The old data directory:
`/var/lib/postgresql/data`
is no longer used, and Postgres now expects a version-specific directory under:
`/var/lib/postgresql/<major-version>/main`
